### PR TITLE
Resolve remote debugging address

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -18,6 +18,7 @@ const path = require('path');
 const http = require('http');
 const https = require('https');
 const URL = require('url');
+const dns = require('dns');
 const removeFolder = require('rimraf');
 const childProcess = require('child_process');
 const BrowserFetcher = require('./BrowserFetcher');
@@ -95,7 +96,7 @@ class Launcher {
       timeout = 30000
     } = options;
 
-    const chromeArguments = [];
+    let chromeArguments = [];
     if (!ignoreDefaultArgs)
       chromeArguments.push(...this.defaultArgs(options));
     else if (Array.isArray(ignoreDefaultArgs))
@@ -105,8 +106,19 @@ class Launcher {
 
     let temporaryUserDataDir = null;
 
-    if (!chromeArguments.some(argument => argument.startsWith('--remote-debugging-')))
+    if (!chromeArguments.some(argument => argument.startsWith('--remote-debugging-'))) {
       chromeArguments.push(pipe ? '--remote-debugging-pipe' : '--remote-debugging-port=0');
+    } else {
+      chromeArguments = await Promise.all(chromeArguments.map(async argument => {
+        if (argument.startsWith('--remote-debugging-address=')) {
+          const result = await dns.promises.lookup(argument.split('=', 2)[1]);
+          argument = '--remote-debugging-address=' + result.address;
+        }
+
+        return argument;
+      }));
+    }
+
     if (!chromeArguments.some(arg => arg.startsWith('--user-data-dir'))) {
       temporaryUserDataDir = await mkdtempAsync(CHROME_PROFILE_PATH);
       chromeArguments.push(`--user-data-dir=${temporaryUserDataDir}`);


### PR DESCRIPTION
I use remote chromium in docker container and puppeteer in another container. I use option `--remote-debugging-address=chromium` (docker compose service name). It is necessary to resolve this address.